### PR TITLE
Fall back to standard Node.js install dir when not on PATH

### DIFF
--- a/scripts/claude-bootstrap-and-run.ps1
+++ b/scripts/claude-bootstrap-and-run.ps1
@@ -6,12 +6,28 @@ $buildEntryPath = Join-Path $repoRoot "build/index.js"
 $npmCommand = "npm.cmd"
 $nodeCommand = "node"
 
+$fallbackNodeDirs = @(
+  "$env:ProgramFiles\nodejs",
+  "${env:ProgramFiles(x86)}\nodejs",
+  "$env:LOCALAPPDATA\Programs\nodejs"
+)
+
 if (-not (Get-Command $nodeCommand -ErrorAction SilentlyContinue)) {
-  throw "Node.js was not found on PATH."
+  $fallbackDir = $fallbackNodeDirs | Where-Object { Test-Path (Join-Path $_ "node.exe") } | Select-Object -First 1
+  if ($fallbackDir) {
+    $nodeCommand = Join-Path $fallbackDir "node.exe"
+  } else {
+    throw "Node.js was not found on PATH."
+  }
 }
 
 if (-not (Get-Command $npmCommand -ErrorAction SilentlyContinue)) {
-  throw "npm was not found on PATH."
+  $fallbackDir = $fallbackNodeDirs | Where-Object { Test-Path (Join-Path $_ "npm.cmd") } | Select-Object -First 1
+  if ($fallbackDir) {
+    $npmCommand = Join-Path $fallbackDir "npm.cmd"
+  } else {
+    throw "npm was not found on PATH."
+  }
 }
 
 if (-not (Test-Path $nodeModulesPath)) {


### PR DESCRIPTION
## Summary
- civil3d-mcp was failing to connect with CONNECTION_CLOSED when Node.js was installed but not resolvable via `Get-Command` in the launching process's PATH
- The bootstrap script now falls back to the standard Node.js install directories (e.g. `C:\Program Files\nodejs`) when `node`/`npm` aren't found on PATH

## Test plan
- [x] Syntax-checked the updated PowerShell script
- [ ] Reconnect the civil3d-mcp MCP server and confirm `civil3d_health` runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the civil3d-mcp bootstrap failing with CONNECTION_CLOSED when Node.js is installed but not on PATH. The script now falls back to standard Node.js install directories instead of throwing immediately when `node` or `npm` aren't resolvable.

<sup>Written for commit a72f930766d179e23d8c0e8f93dd8d16277956c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sacred-G/Civil3D-mcp/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

